### PR TITLE
Docs for version 1.1.0

### DIFF
--- a/docs/02.Messages.md
+++ b/docs/02.Messages.md
@@ -48,3 +48,33 @@ configuration by visiting this page:
 http://192.168.1.201/messages.json
 ```
 
+### Startup Messages
+
+##### (from v1.1.0)
+
+Oschii can send a set of messages when it starts up. These are sent *after* the device has 
+connected to the network.
+
+To do this, add a JSON array under the top-level key `"Startup"`. Each object in this array
+consists of a Message Builder and a Target Component Reference (these are explained elsewhere in the 
+documentation).
+
+If the Startup array below is added to a configuration, Oschii will send two messages when it
+first connects to the network. One will illuminate a local LED for two seconds, the other sends
+a message to a reporter which causes an LED there to flash three times. The component definitions
+are not shown.
+
+```json
+{
+  "Startup": [
+    {
+      "message": [100, 50, 1950],
+      "target": "Driver:Green"
+    },
+    {
+      "message": [100, 50, 0, 0, 250, 0, -1, 3],
+      "target": "Reporter:Bob/Green"
+    }
+  ]
+}
+```

--- a/docs/03.Components.md
+++ b/docs/03.Components.md
@@ -236,35 +236,35 @@ etc. Components are processed in the order they appear within the array. You sho
 
 ### Component Feature Summary
 
-| Type                             | Subtype | Conditions? | Message Builders? | Value Transforms? | Subs? | Send to Target? | Used as Target? |
-|----------------------------------|---------|-------------|-------------------|-------------------|-------|-----------------|-----------------|
+| Type                            | Subtype | Conditions? | Message Builders? | Value Transforms? | Subs? | Send to Target? | Used as Target? |
+|---------------------------------|---------|-------------|-------------------|-------------------|-------|-----------------|-----------------|
 | [**Sensor**](04.Sensors.md)     | gpio    | YES         | YES               | -                 | -     | YES             | -               |
-|                                  | touch   | YES         | YES               | -                 | -     | YES             | -               |
-|                                  | analog  | YES         | YES               | YES               | -     | YES             | -               |
-|                                  | hc-sr04 | YES         | YES               | YES               | -     | YES             | -               |
-|                                  |         |             |                   |                   |       |                 |                 |
+|                                 | touch   | YES         | YES               | -                 | -     | YES             | -               |
+|                                 | analog  | YES         | YES               | YES               | -     | YES             | -               |
+|                                 | hc-sr04 | YES         | YES               | YES               | -     | YES             | -               |
+|                                 |         |             |                   |                   |       |                 |                 |
 | [**Driver**](05.Drivers.md)     | gpio    | YES         | -                 | -                 | -     | -               | YES             |
-|                                  | pwm     | YES         | -                 | YES               | -     | -               | YES             |
-|                                  | dimmer  | YES         | -                 | YES               | -     | -               | YES             |
-|                                  |         |             |                   |                   |       |                 |                 |
+|                                 | pwm     | YES         | -                 | YES               | -     | -               | YES             |
+|                                 | dimmer  | YES         | -                 | YES               | -     | -               | YES             |
+|                                 |         |             |                   |                   |       |                 |                 |
 | [**Listener**](06.Listeners.md) |         | YES         | YES               | YES               | YES   | YES             | YES             |
-|                                  |         |             |                   |                   |       |                 |                 |
-| [**Reporter**](07.Reporters.md) |         | -           | -                 | -                 | -     | -               | YES             |
-|                                  |         |             |                   |                   |       |                 |                 |
+|                                 |         |             |                   |                   |       |                 |                 |
+| [**Reporter**](07.Reporters.md) |         | -           | -                 | -                 | -     | YES             | YES             |
+|                                 |         |             |                   |                   |       |                 |                 |
 | [**Monitor**](08.Monitors.md)   |         | YES         | YES               | YES               | YES   | YES             | -               |
-|                                  |         |             |                   |                   |       |                 |                 |
+|                                 |         |             |                   |                   |       |                 |                 |
 | [**State**](09.States.md)       |         | YES         | YES               | -                 | YES   | YES             | YES             |
-|                                  |         |             |                   |                   |       |                 |                 |
-| [**Timer**](10.Timers.md)      |         | YES         | YES               | YES               | -     | YES             | YES             |
-|                                  |         |             |                   |                   |       |                 |                 |
-| [**I2C**](11.I2C.md)           | gpio    | -           | -                 | -                 | -     | -               | YES             |
-|                                  | pwm     | -           | -                 | -                 | -     | -               | YES             |
-|                                  | analog  | -           | -                 | -                 | -     | -               | -               |
-|                                  | keypad  | -           | -                 | -                 | -     | YES             | YES             |
-|                                  | mp3     | -           | -                 | -                 | -     | -               | YES             |
-|                                  | generic | -           | -                 | -                 | -     | -               | YES             |
-|                                  |         |             |                   |                   |       |                 |                 |
-| [**Pixel**](12.Pixels.md)      |         | YES         | -                 | -                 | YES*  | -               | YES             |
+|                                 |         |             |                   |                   |       |                 |                 |
+| [**Timer**](10.Timers.md)       |         | YES         | YES               | YES               | -     | YES             | YES             |
+|                                 |         |             |                   |                   |       |                 |                 |
+| [**I2C**](11.I2C.md)            | gpio    | -           | -                 | -                 | -     | -               | YES             |
+|                                 | pwm     | -           | -                 | -                 | -     | -               | YES             |
+|                                 | analog  | -           | -                 | -                 | -     | -               | -               |
+|                                 | keypad  | -           | -                 | -                 | -     | YES             | YES             |
+|                                 | mp3     | -           | -                 | -                 | -     | -               | YES             |
+|                                 | generic | -           | -                 | -                 | -     | -               | YES             |
+|                                 |         |             |                   |                   |       |                 |                 |
+| [**Pixel**](12.Pixels.md)       |         | YES         | -                 | -                 | YES*  | -               | YES             |
 
 *Pixel Subs are called *Layers*, and may be referenced directly using the target address syntax, e.g. 
 `Pixel:MyPixel/TopLayer`

--- a/docs/06.Listeners.md
+++ b/docs/06.Listeners.md
@@ -13,10 +13,11 @@ can be called from other components.
 
 ### JSON Definition
 
-| Property     | Description                       | Value         | Default                            |
-|--------------|-----------------------------------|---------------|------------------------------------|
-| `osc`        | Accept OSC                        | Boolean       | true                               |
-| `httpMethod` | Accept HTTP with specified method | "get", "post" | (HTTP only enabled if this is set) |
+| Property          | Description                       | Value           | Default                            |
+|-------------------|-----------------------------------|-----------------|------------------------------------|
+| `osc`             | Accept OSC                        | Boolean         | true                               |
+| `httpMethod`      | Accept HTTP with specified method | "get", "post"   | (HTTP only enabled if this is set) |
+| `responseMessage` | Message Builder for HTTP response | Message Builder |                                    |
 
 ### Operation
 
@@ -29,6 +30,29 @@ to its `target` component(s).
 
 If any `target` components are defined on the parent Listener, they are added to the `target` set of each Sub.
 A Listener itself never sends messages, only its Subs do.
+
+### Response Message
+
+##### (from v1.1.0)
+
+Unlike OSC, HTTP follows a request/response pattern. A Listener using HTTP can define a Message Builder
+object to build the response sent back when the Listener is called over HTTP.
+
+This partial example defines a HTTP GET Listener which returns the current values of four buttons:
+
+```json
+{
+  "Listeners": [
+    {
+      "name": "ButtonStates",
+      "httpMethod": "get",
+      "responseMessage": [ "Sensor:Button1", "Sensor:Button2", "Sensor:Button3", "Sensor:Button4" ]
+    }
+  ]
+}
+```
+
+Note that although this Listener will also accept OSC, the response builder has no effect with OSC. 
 
 ### Example 1
 

--- a/docs/07.Reporters.md
+++ b/docs/07.Reporters.md
@@ -5,8 +5,7 @@ network.
 
 Reporters are defined by JSON objects in a top-level array called `"Reporters"`.
 
-Reporters do not support Conditions, Message Builders, Value Transforms, or Subs, and they cannot
-send messages to other components.
+Reporters do not support Conditions, Message Builders, Value Transforms, or Subs.
 
 By default, a Reporter will use OSC. To use HTTP instead, set `httpMethod` to a valid value.
 
@@ -20,6 +19,10 @@ The message held by an OSC Reporter will be the last message it sent out. An HTT
 response status code of its last HTTP request.
 
 When sending messages to a Reporter, we specify the OSC/HTTP address within the Component Reference.
+
+A Reporter can send a message to other components after the network call is complete.
+With an OSC Reporter this message will be the one sent to the Reporter itself. With a HTTP Reporter
+this will be the message returned from the HTTP endpoint. (This feature was added in v1.1.0)
 
 ### JSON Definition
 


### PR DESCRIPTION
Documentation for v1.1.0:
- Response Message Builder for HTTP Listeners
- Enable targets for Reporters
- Startup messages
